### PR TITLE
Update treinazapvinicius88-prd.yml

### DIFF
--- a/.github/workflows/treinazapvinicius88-prd.yml
+++ b/.github/workflows/treinazapvinicius88-prd.yml
@@ -8,7 +8,7 @@ on:
   
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Altere a versão do ubuntu-latest para a 18.04 e pode remover as linhas:

      - name: INSTALL AWS CLIENT
        run: pip install awscli

Por padrão o agent do github actions já vem com uma versão do awscli e não precisa fazer a instalação.

Veja aqui como deve ficar o GitHub Actions:

https://treinacloud.gitbook.io/cloudops/docs